### PR TITLE
More elaborate version

### DIFF
--- a/i-am-a-new-teacher.md
+++ b/i-am-a-new-teacher.md
@@ -1,10 +1,50 @@
 # I'm a (new) teacher!
 
-### Super nice that you joined our HYF teaching team, here are some practical things to help you get started:
-
-**Please read the [HackYourFuture core values](https://github.com/HackYourFuture/curriculum/blob/master/hyf-core-values.md)**
+### Super nice that you are interested in becoming part of the HYF teaching team! Below you can find information about what it entails to be a volunteer, and what role you can play in our organsisation. 
 
 \*:information_desk_person: If you don't have access to one of the things mentioned below, ask Gijs.
+
+**Introduction:**
+
+HackYourFuture is a program that teaches programming to refugees/newcomers in order to start their career as a software developer. Thanks to a large team of volunteers we are able to run our program and we have helped dozens (60+) of our students find jobs as programmers. Finding work has an incredible impact on the lives of our students, and our goal is to prepare them as well as possible for the demands of the job market. 
+
+Our program consists of 8 modules:
+
+1. HTML/CSS -- 3 weeks
+2. JavaScript1 -- 3 weeks
+3. JavaScript2 -- 3 weeks
+4. JavaScript3 -- 3 weeks
+5. Node -- 3 weeks
+6. Databases -- 3 weeks
+7. React -- 5 weeks
+8. Project --  6 weeks
+
+Total: 28 weeks
+
+**Roles**
+
+Within HackYourFuture you can be active in various roles, depending on your skillset, experience, preference and availability. 
+
+Teachers:
+
+Teachers are people that commit to teaching a module for 3 weeks. Together with another volunteer teacher, they will teach classes on Sundays for three weeks in a row. During the week they will check slack occasionaly to see whether students are stuck with homework, and try to help them in the right direction. If you start teaching the first time, you will always be paired with a more experienced teacher who can support you in the process of teaching. 
+
+Teaching assistants(TA):
+
+TA's are volunteers that help a class in a variety of ways. TA' sit in the class during the lecture, and jump in as soon students are working on problems by themselves and are stuck. Next to that they can get involved in giving feedback on the students homework during the week (very valuable), helping students with questions on slack, and indiviually mentoring students who are struggling. In general TA's commit to a module, but we can a bit more flexible with this commitment. 
+
+Technical interviewer:
+
+After graduation we do mock interviews with our students in order to train their interviewing skills. The technical interviewer, together with a non-technical interviewer, will test the students ability to perform well in an interview and will give them detailed feedback on their performance. 
+
+
+**Onboarding Teachers**
+
+The first step of onboarding is to invite you over to our classrooms on a Sunday. We will guide you through our classrooms,introduce you to some students/teachers, and will ask you to sit in a few classes to explore how our program works in reality. After this we hope you have a better picture of 
+1. whether you like being a volunteer
+2. what role you'd like to play within HackYourFuture
+
+Based on your skillset and availability you will be asked to teach/TA for a specific module by the Education Director.
 
 **Slack**
 - Our Slack has channels for every class, the main goal here is that we support students with questions/their homework during the week. You of course don't have to join all of them, but please join the channel of the class that you are currently teaching or helping out with. If you are not in Slack yet: :information_desk_person: 
@@ -12,15 +52,16 @@
 
 **Modules**
 - All modules have their own repository in our Github organization.
-- We also have a nice and shiny overview of our [curriculum](https://github.com/HackYourFuture/curriculum). Here you can find information about when/how and what we teach.
+- For more detailed information on the curriculum have a look at our[curriculum on Github](https://github.com/HackYourFuture/curriculum). Here you can find information about when/how and what we teach.
 - We divided everyone in our organization into teams, we have a teachers team, a team for every class etc. which all have different permissions.
 - We have a private repository where fellow teachers share their [BestTeachingPractices](https://github.com/HackYourFuture/BestTeachingPractices), if you are new to teaching or are just curious on what they think works well in class, take a look.
 - If you are teaching a certain module and would like to make changes on the contents of the repo, please create a branch with your name and your fellow teacher, like: `yourname_othername`. Our master branches are protected, if you would like to change something to the default module please make a PR.
+- We highly encourage you to make pull-requests to improve our curriculum!
 
 **Homework**
 - *Trello* is used in the first three modules to hand in homework (first zip files) later links to Github repositories. :information_desk_person:
 - Later on we use [this](https://github.com/HackYourFuture/Git/blob/master/Lecture-3.md) method to hand in homework.
-- All homework is given feedback by teachers, we do this by commenting on the pull-requests of the students and asking for improvements. 
+- All student get feedback on their homework from teachers/Ta's, we do this by commenting on the pull-requests of the students and asking for improvements. 
 
 **Any other questions?**:arrow_right: :information_desk_person:
 


### PR DESCRIPTION
- removed core values, as they are clearly written for students, not for teachers
- added a more specific overview of what teaching entails at HYF for teachers that will come the first time
- added clear overview of what roles there are in HYF
- added overview of modules. A simple link to the curriculum link doesn't suffice here in terms of clarity, and making sure the teacher reads the content you want them to understand
@wouterkleijn have some feedback maybe?